### PR TITLE
add `cookie_samesite` to `\Zend_Session::$_defaultOptions`

### DIFF
--- a/src/Zend/Session.php
+++ b/src/Zend/Session.php
@@ -99,6 +99,7 @@ class Zend_Session extends Zend_Session_Abstract
         'cookie_domain'           => null,
         'cookie_secure'           => null,
         'cookie_httponly'         => null,
+        'cookie_samesite'         => null,
         'use_cookies'             => null,
         'use_only_cookies'        => 'on',
         'referer_check'           => null,


### PR DESCRIPTION
Je to zmena ktoru mergli do `diablomedia/zf1-session` ale pokial vydaju tag tak pouzijeme nas fork.

Pozeral som sa na testy, ale nieje to tam potreba imho, testuje sa tam len ze ked tam nastavis nepovolenu hodnotu tak to hodi exception, to ze tam das validnu hodnotu max otestujes ze skontrolujes to pole `_defaultOptions ` ze sa to do toho pridalo, to mi pride zbytocne 